### PR TITLE
Projects dashboard component

### DIFF
--- a/spec/components/projects-dashboard.spec.js
+++ b/spec/components/projects-dashboard.spec.js
@@ -1,0 +1,20 @@
+describe('ProjectsDashboard', () => {
+    let $output, projectDetail, rewardDetail,
+        ProjectsDashboard = window.c.root.ProjectsDashboard;
+
+    describe('view', () => {
+        beforeAll(() => {
+            projectDetail = ProjectDetailsMockery()[0];
+            rewardDetail = RewardDetailsMockery()[0];
+            let component = m.component(ProjectsDashboard, {
+                project_id: projectDetail.project_id,
+                project_user_id: projectDetail.user.id,
+            });
+            $output = mq(component);
+        });
+
+        it('should render project about and reward list', () => {
+            expect($output.has('.project-nav-wrapper')).toBeTrue();
+        });
+    });
+});

--- a/spec/lib/mocks/project-details.mock.js
+++ b/spec/lib/mocks/project-details.mock.js
@@ -13,6 +13,7 @@ beforeAll(function(){
       online_date: "2015-07-13T10:19:40.193106-03:00",
       sent_to_analysis_at: "2014-07-01T23:01:05.640456",
       is_published: true,
+      is_owner_or_admin: true,
       is_expired: false,
       open_for_contributions: true,
       reminder_count: 23,

--- a/src/c.js
+++ b/src/c.js
@@ -2,6 +2,7 @@ window.c = (function() {
     return {
         models: {},
         root: {},
+        vms: {},
         admin: {},
         h: {}
     };

--- a/src/root/projects-dashboard.js
+++ b/src/root/projects-dashboard.js
@@ -6,16 +6,17 @@
  * To mount this component just create a DOM element like:
  * <div data-mithril="ProjectsDashboard">
  */
-window.c.root.ProjectsDashboard = ((m, c, h, _) => {
+window.c.root.ProjectsDashboard = ((m, c, h, _, vms) => {
     return {
 
-        controller: () => {
-            alert('dashboard');
+        controller: (args) => {
+            return vms.project(args.project_id, args.project_user_id);
         },
 
         view: (ctrl) => {
+            const project = ctrl.projectDetails();
             return project.is_owner_or_admin ?
                 m.component(c.ProjectDashboardMenu, {project: project}) : '';
         }
     };
-}(window.m, window.c, window.c.h, window._));
+}(window.m, window.c, window.c.h, window._, window.c.vms));

--- a/src/root/projects-dashboard.js
+++ b/src/root/projects-dashboard.js
@@ -13,6 +13,9 @@ window.c.root.ProjectsDashboard = ((m, c, h, _) => {
             alert('dashboard');
         },
 
-        view: (ctrl) => {}
+        view: (ctrl) => {
+            return project.is_owner_or_admin ?
+                m.component(c.ProjectDashboardMenu, {project: project}) : '';
+        }
     };
 }(window.m, window.c, window.c.h, window._));

--- a/src/root/projects-dashboard.js
+++ b/src/root/projects-dashboard.js
@@ -1,0 +1,18 @@
+/**
+ * window.c.root.ProjectsDashboard component
+ * A root component to manage projects
+ *
+ * Example:
+ * To mount this component just create a DOM element like:
+ * <div data-mithril="ProjectsDashboard">
+ */
+window.c.root.ProjectsDashboard = ((m, c, h, _) => {
+    return {
+
+        controller: () => {
+            alert('dashboard');
+        },
+
+        view: (ctrl) => {}
+    };
+}(window.m, window.c, window.c.h, window._));

--- a/src/root/projects-explore.js
+++ b/src/root/projects-explore.js
@@ -12,7 +12,7 @@ window.c.root.ProjectsExplore = ((m, c, h, _, moment) => {
         controller: () => {
             const filters = m.postgrest.filtersVM,
                   follow = c.models.categoryFollower,
-                  filtersMap = c.root.projectFilters(),
+                  filtersMap = c.vms.projectFilters(),
                   categoryCollection = m.prop([]),
                   // Fake projects object to be able to render page while loadding (in case of search)
                   projects = m.prop({collection: m.prop([]), isLoading: () => { return true; }}),

--- a/src/root/projects-home.js
+++ b/src/root/projects-home.js
@@ -7,7 +7,7 @@ window.c.root.ProjectsHome = (((m, c, moment, h, _) => {
                 loaderWithToken = m.postgrest.loaderWithToken,
                 loader = _.partial(m.postgrest.loader, _, m.postgrest.request),
                 project = c.models.project,
-                filters = c.root.projectFilters();
+                filters = c.vms.projectFilters();
 
             const collections = _.map(['near_me', 'recommended', 'expiring', 'recent'], (name) => {
                 const f = filters[name],

--- a/src/root/projects-show.js
+++ b/src/root/projects-show.js
@@ -1,41 +1,13 @@
-window.c.root.ProjectsShow = ((m, c, _, models, h) => {
+window.c.root.ProjectsShow = ((m, c, _, h, vms) => {
     return {
         controller: (args) => {
-            const vm = m.postgrest.filtersVM({
-                    project_id: 'eq'
-                }),
-                idVM = h.idVM,
-                projectDetails = m.prop([]),
-                userDetails = m.prop([]),
-                rewardDetails = m.prop([]);
-
-            vm.project_id(args.project_id);
-            idVM.id(args.project_user_id);
-
-            const lProject = m.postgrest.loaderWithToken(models.projectDetail.getRowOptions(vm.parameters())),
-                lUser = m.postgrest.loaderWithToken(models.userDetail.getRowOptions(idVM.parameters())),
-                lReward = m.postgrest.loaderWithToken(models.rewardDetail.getPageOptions(vm.parameters()));
-
-            lProject.load().then((data) => {
-                lUser.load().then(userDetails);
-                lReward.load().then(rewardDetails);
-
-                projectDetails(data);
-            });
-
-            return {
-                projectDetails: projectDetails,
-                userDetails: userDetails,
-                rewardDetails: rewardDetails,
-                lProject: lProject,
-                lUser: lUser,
-                lReward: lReward
-            };
+            return vms.project(args.project_id, args.project_user_id);
         },
 
         view: (ctrl) => {
-            return (!(ctrl.lProject() || ctrl.lUser() || ctrl.lReward())) ? _.map(ctrl.projectDetails(), (project) => {
-                return m('.project-show', {
+            const project = ctrl.projectDetails();
+            return (!ctrl.isLoading()) ?
+                m('.project-show', {
                     config: h.mixpanelTrack()
                 }, [
                     m.component(c.ProjectHeader, {
@@ -53,8 +25,7 @@ window.c.root.ProjectsShow = ((m, c, _, models, h) => {
                     (project.is_owner_or_admin ? m.component(c.ProjectDashboardMenu, {
                         project: project
                     }) : '')
-                ]);
-            }) : h.loader();
+                ]) : h.loader();
         }
     };
-}(window.m, window.c, window._, window.c.models, window.c.h));
+}(window.m, window.c, window._, window.c.h, window.c.vms));

--- a/src/root/start.js
+++ b/src/root/start.js
@@ -9,7 +9,7 @@ window.c.root.Start = ((m, c, h, models, I18n) => {
                 selectedCategory = m.prop([]),
                 featuredProjects = m.prop([]),
                 selectedCategoryIdx = m.prop(-1),
-                startvm = c.root.startVM(I18n),
+                startvm = c.vms.start(I18n),
                 filters = m.postgrest.filtersVM,
                 paneImages = startvm.panes,
                 categoryvm = filters({

--- a/src/vms/project-filters.js
+++ b/src/vms/project-filters.js
@@ -1,4 +1,4 @@
-window.c.root.projectFilters = ((m, h, moment) => {
+window.c.vms.projectFilters = ((m, h, moment) => {
     return () =>{
         const filters = m.postgrest.filtersVM,
 

--- a/src/vms/project.js
+++ b/src/vms/project.js
@@ -1,0 +1,33 @@
+window.c.vms.project = ((m, h, _, models) => {
+    return (project_id, project_user_id) =>{
+        const vm = m.postgrest.filtersVM({
+            project_id: 'eq'
+        }),
+              idVM = h.idVM,
+              projectDetails = m.prop([]),
+              userDetails = m.prop([]),
+              rewardDetails = m.prop([]);
+
+        vm.project_id(project_id);
+        idVM.id(project_user_id);
+
+        const lProject = m.postgrest.loaderWithToken(models.projectDetail.getRowOptions(vm.parameters())),
+              lUser = m.postgrest.loaderWithToken(models.userDetail.getRowOptions(idVM.parameters())),
+              lReward = m.postgrest.loaderWithToken(models.rewardDetail.getPageOptions(vm.parameters())),
+              isLoading = () => { return (lProject() || lUser() || lReward()); };
+
+        lProject.load().then((data) => {
+            lUser.load().then(userDetails);
+            lReward.load().then(rewardDetails);
+
+            projectDetails(data);
+        });
+
+        return {
+            projectDetails: _.compose(_.first, projectDetails),
+            userDetails: userDetails,
+            rewardDetails: rewardDetails,
+            isLoading: isLoading
+        };
+    };
+}(window.m, window.c.h, window._, window.c.models));

--- a/src/vms/start.js
+++ b/src/vms/start.js
@@ -1,4 +1,4 @@
-window.c.root.startVM = ((_) => {
+window.c.vms.start = ((_) => {
     return (I18n) => {
         const i18nStart = I18n.translations[I18n.currentLocale()].pages.start,
             testimonials = i18nStart.testimonials,


### PR DESCRIPTION
Just some basic functionality and some refactoring. Mainly:
 * Moves all VMs to a separate namespace (since they cannot be mounted they shouldn't be in root).
 * Moves project details loading to a separate VM to use the same logic for project show and dashboard.
 * Creates dashboard component that loads projects and renders sidebar.