### PR TITLE
Removes near_me, expiring and recent project rows from projects home …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catarse.js",
-  "version": "0.7.4"
+  "version": "0.7.4",
   "author": "Diogo Biazus",
   "contributors": [
     {

--- a/src/root/projects-home.js
+++ b/src/root/projects-home.js
@@ -9,7 +9,7 @@ window.c.root.ProjectsHome = (((m, c, moment, h, _) => {
                 project = c.models.project,
                 filters = c.vms.projectFilters();
 
-            const collections = _.map(['near_me', 'recommended', 'expiring', 'recent'], (name) => {
+            const collections = _.map(['recommended'], (name) => {
                 const f = filters[name],
                       cLoader = loaderWithToken(project.getPageOptions(f.filter.parameters())),
                       collection = m.prop([]);


### PR DESCRIPTION
…[fix #111027220]

I'm leaving the map there to make it easy to add rows again later.