### PR TITLE
use init on getCurrentProject to always load project from api [Fix #1…

### DIFF
--- a/src/vms/project-vm.js
+++ b/src/vms/project-vm.js
@@ -53,7 +53,7 @@ const getCurrentProject = () => {
 
         m.redraw(true);
 
-        fetchParallelData(project_id, project_user_id);
+        init(project_id, project_user_id);
 
         return currentProject();
     } else {


### PR DESCRIPTION
…30797443]