### PR TITLE
fixes minimum value reset when no reward is selected

### DIFF
--- a/src/vms/reward-vm.js
+++ b/src/vms/reward-vm.js
@@ -54,10 +54,13 @@ const getSelectedReward = () => {
 };
 
 const selectReward = reward => () => {
+    const currentValue = h.monetaryToFloat(contributionValue);
     if (selectedReward() !== reward) {
         error('');
         selectedReward(reward);
-        contributionValue(h.applyMonetaryMask(`${reward.minimum_value},00`));
+        if (currentValue < reward.minimum_value) {
+            contributionValue(h.applyMonetaryMask(`${reward.minimum_value},00`));
+        }
         if (reward.id) {
             getFees(reward).then(fees);
         }


### PR DESCRIPTION
### Why

When no reward is selected we end up making an extra call to the selectReward method, which would reset the contribution value to match the minimum reward value. This allows us to keep the contribution value if it's value is higher then the current minimum. 