### PR TITLE
use empty object when user not loaded

### DIFF
--- a/src/vms/reward-vm.js
+++ b/src/vms/reward-vm.js
@@ -158,7 +158,7 @@ const shippingFeeForCurrentReward = (selectedDestination) => {
     return currentFee;
 };
 
-const canEdit = (reward, projectState, user) => user.is_admin || (projectState === 'draft' || (projectState === 'online' && reward.paid_count <= 0 && reward.waiting_payment_count <= 0));
+const canEdit = (reward, projectState, user) => (user||{}).is_admin || (projectState === 'draft' || (projectState === 'online' && reward.paid_count <= 0 && reward.waiting_payment_count <= 0));
 
 const canAdd = projectState => projectState === 'draft' || projectState === 'online';
 


### PR DESCRIPTION
### Why

When mithril are redering using a async m.prop sometimes the user attribute is undefined or null, just add a check to use an empty object to avoid raise error