### PR TITLE
use older version of chartjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "chart.js": "^2.6.0",
+    "chart.js": "1.0.2",
     "diacritics": "^1.2.3",
     "i18n-js": "^1.0.0",
     "jquery": "^3.1.1",


### PR DESCRIPTION
This is the version of chart.js we were using with bower. We should consider updating our code to use the newer one. ;)