### PR TITLE
Change info about time needed for visitors data

### DIFF
--- a/src/c/project-data-stats.js
+++ b/src/c/project-data-stats.js
@@ -71,7 +71,7 @@ const projectDataStats = {
                     ])
                 ]),
                 m('.fontcolor-secondary.fontsize-smallest.u-margintop-20', [
-                    'Os dados podem levar até 12 horas para serem atualizados.',
+                    'Os dados podem levar até 24 horas para serem atualizados.',
                     m('a.alt-link', { href: 'https://suporte.catarse.me/hc/pt-br/articles/115002214463-projeto-ONLINE#visitante', target: '_blank' }, ' Saiba mais'),
                     '.'
                 ])


### PR DESCRIPTION
It takes up to 24 hours to get the data from GA, instead of 12 hours.