### PR TITLE
add page_title and page_url to message data #157760520

### DIFF
--- a/src/c/owner-message-content.js
+++ b/src/c/owner-message-content.js
@@ -38,7 +38,11 @@ const ownerMessageContent = {
                 user_id: h.getUser().user_id,
                 content: content(),
                 project_id: args().project_id,
-                to_user_id: userDetails().id
+                to_user_id: userDetails().id,
+		data: {
+			page_title: document.title,
+			page_url: window.location.href
+		}
             });
 
             l = catarse.loaderWithToken(loaderOpts);


### PR DESCRIPTION
### Why

Send page url and title via direct message post to use it to render notification with message origin information.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Flowtype
- [ ] DocBlock's added
- [ ] Strings are translated
- [ ] Code is reviewed
