### PR TITLE
Order subscriptions report by last payment paid

### DIFF
--- a/src/root/projects-subscription-report.js
+++ b/src/root/projects-subscription-report.js
@@ -31,10 +31,9 @@ const projectSubscriptionReport = {
             error = m.prop(false),
             loader = m.prop(true),
             rewards = m.prop([]),
-            subscriptions = commonPayment.paginationVM(models.userSubscription, 'created_at.desc', {
-                Prefer: 'count=exact'
-            }),
+            subscriptions = commonPayment.paginationVM(models.userSubscription, 'paid_at.desc'),
             submit = () => {
+                filterVM.order({paid_at:'desc'});
                 if (filterVM.reward_external_id() === 'null') {
                     subscriptions.firstPage(filterVM.withNullParameters()).then(null);
                 } else {
@@ -175,6 +174,7 @@ const projectSubscriptionReport = {
 
         lProject.load().then((data) => {
             filterVM.project_id(_.first(data).common_id);
+            filterVM.order({paid_at:'desc'});
             subscriptions.firstPage(filterVM.parameters()).then(() => {
                 loader(false);
             }).catch(handleError);

--- a/src/root/projects-subscription-report.js
+++ b/src/root/projects-subscription-report.js
@@ -33,6 +33,7 @@ const projectSubscriptionReport = {
             rewards = m.prop([]),
             subscriptions = commonPayment.paginationVM(models.userSubscription, 'paid_at.desc'),
             submit = () => {
+                // Set order by last paid on filters too
                 filterVM.order({paid_at:'desc'});
                 if (filterVM.reward_external_id() === 'null') {
                     subscriptions.firstPage(filterVM.withNullParameters()).then(null);
@@ -174,6 +175,7 @@ const projectSubscriptionReport = {
 
         lProject.load().then((data) => {
             filterVM.project_id(_.first(data).common_id);
+            // override default 'created_at' order on vm
             filterVM.order({paid_at:'desc'});
             subscriptions.firstPage(filterVM.parameters()).then(() => {
                 loader(false);


### PR DESCRIPTION
### Why

Changed the order to paid_at column on subscriptions view.

### Wrap up checklist

- [ ] All new code has tests
- [ ] All strings are translated
- [ ] Code is reviewed
