### PR TITLE
Removing btn-inline from load-more button component

### DIFF
--- a/legacy/src/c/load-more-btn.js
+++ b/legacy/src/c/load-more-btn.js
@@ -18,7 +18,7 @@ const loadMoreBtn = {
             cssClass = args.cssClass;
         return m(`.w-col.w-col-4${cssClass}`, [
               (!collection.isLoading() ?
-               (collection.isLastPage() ? '' : m('button#load-more.btn.btn-small.btn-inline.btn-terciary.w-button', {
+               (collection.isLastPage() ? '' : m('button#load-more.btn.btn-small.btn-terciary.w-button', {
                    onclick: collection.nextPage
                }, 'Carregar mais')) : h.loader())
         ]);


### PR DESCRIPTION
@grpse I had to remove the btn-inline class because I found one place that it was weird with this class applied. It should be fine now!

### Why

Because ths load more component button is reusable, I am just making some fine adjustments to make sure that it fits nicely in all the places.

### Wrap up checklist

- [X] All new code has tests
- [X] All strings are translated
- [ ] Code is reviewed
