### PR TITLE
show account type on balance request #159591681

### DIFF
--- a/legacy/src/c/user-balance-request-modal-content.js
+++ b/legacy/src/c/user-balance-request-modal-content.js
@@ -158,6 +158,11 @@ const userBalanceRequestModelContent = {
                             m('span.fontcolor-secondary', window.I18n.t('bank.account', I18nScope())),
                             m.trust('&nbsp;'),
                             `${item.account}-${item.account_digit}`
+                        ]),
+                        m('div', [
+                            m('span.fontcolor-secondary', window.I18n.t('bank.account_type', I18nScope())),
+                            m.trust('&nbsp;'),
+                            window.I18n.t(`bank.${item.account_type}`, I18nScope())
                         ])
                     ])
                 ])


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

Using I18n with string interpolation, show up account type name on confirmation modal for balance request.

### Wrap up checklist

- [ ] All new code has tests
- [x] All strings are translated
- [ ] Code is reviewed
