### PR TITLE
Fix liquidjs non-es5 compatible issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
         },
       },
     ]
-  ]
+  ],
+  "plugins": ["syntax-dynamic-import"]
 }

--- a/legacy/src/root/admin-notifications.js
+++ b/legacy/src/root/admin-notifications.js
@@ -3,14 +3,12 @@ import h from '../h';
 import _ from 'underscore';
 import { catarse, commonNotification } from '../api';
 import models from '../models';
-import Liquid from 'liquidjs';
 import projectEditSaveBtn from '../c/project-edit-save-btn';
 
 const adminNotifications = {
     controller: function() {
         const templates = commonNotification.paginationVM(
             models.notificationTemplates, 'label.asc'),
-            engine = Liquid(),
             loaderTemp = m.prop(true),
             loaderSubmit = m.prop(false),
             selectedItem = m.prop(),
@@ -24,24 +22,6 @@ const adminNotifications = {
                 user: {
                     name: 'test name user'
                 }
-            },
-            renderSubjectTemplate = (tpl) => {
-                const tplParsed = engine.parse(h.stripScripts(tpl));
-                engine.render(tplParsed, templateDefaultVars)
-                    .then((html) => {
-                        parsedSubjectTemplate(h.stripScripts(tpl));
-                        renderedSubjectTemplate(html);
-                        m.redraw();
-                    });
-            },
-            renderTemplate = (tpl) => {
-                const tplParsed = engine.parse(h.stripScripts(tpl));
-                engine.render(tplParsed, templateDefaultVars)
-                    .then((html) => {
-                        parsedTemplate(h.stripScripts(tpl));
-                        renderedTemplate(html);
-                        m.redraw();
-                    });
             },
             changeSelectedTo = collection => (evt) => {
                 const item = _.find(collection, { label: evt.target.value });
@@ -69,6 +49,34 @@ const adminNotifications = {
                     templates.firstPage({}).then(() => { loaderSubmit(false); });
                 });
             };
+
+        let engine;
+        let renderSubjectTemplate;
+        let renderTemplate;
+
+        import('liquidjs').then(Liquid => {
+            engine = Liquid();
+
+            renderSubjectTemplate = (tpl) => {
+                const tplParsed = engine.parse(h.stripScripts(tpl));
+                engine.render(tplParsed, templateDefaultVars)
+                    .then((html) => {
+                        parsedSubjectTemplate(h.stripScripts(tpl));
+                        renderedSubjectTemplate(html);
+                        m.redraw();
+                    });
+            };
+
+            renderTemplate = (tpl) => {
+                const tplParsed = engine.parse(h.stripScripts(tpl));
+                engine.render(tplParsed, templateDefaultVars)
+                    .then((html) => {
+                        parsedTemplate(h.stripScripts(tpl));
+                        renderedTemplate(html);
+                        m.redraw();
+                    });
+            };
+        });
 
         templates.firstPage({}).then(() => { loaderTemp(false); });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,6 +1119,12 @@
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.1.4",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.7.0",
     "elm-webpack-loader": "^4.5.0",
     "eslint": "^3.16.0",


### PR DESCRIPTION
This fixes an issue we were having because of liquidjs. After a recent
release, liquidjs was no longer compatible with es5. This makes sure we
only require the module dynamically. Because it is only used on an admin
page, it shouldn't be an issue to load it there.

Signed-off-by: Vinicius Andrade <vini.andrade.dev@gmail.com>

### Why

Explain what this PR does.

### Wrap up checklist

- [ ] All new code has tests
- [ ] All strings are translated
- [ ] Code is reviewed
